### PR TITLE
Set App Header with "appName" Param

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -31,7 +31,7 @@ export const App: React.FunctionComponent = () => {
     }
   };
 
-  //test commit
+  const appName = utils.isAppNameInUrl(); //Calls the method to check if the app name is in the URL
 
   return (
     <ThemeProvider applyTo="body" theme={disableDarkMode ? lightTheme : darkTheme}>
@@ -46,7 +46,7 @@ export const App: React.FunctionComponent = () => {
             />
           </div>
           <div style={{ paddingBottom: '15px' }}>
-            <Text variant={'xLarge'}> Michael's URL Param Tester </Text>
+            <Text variant={'xLarge'}> {appName} </Text>
           </div>
           <ListItemsComponent props={searchParams} />
         </Stack>

--- a/src/app/components/ListItemsComponent.tsx
+++ b/src/app/components/ListItemsComponent.tsx
@@ -20,7 +20,7 @@ const ListItemsComponent = ( props: any ) => {
   if ( props.props === undefined ) {
     return <NoParamsMessage />
   } else {
-    let excludeAppNameKey = props.props.filter((data: { key: string; }) => data.key !== 'appName'); //Dirty fix that excludes the appName URL param/value from being rendered in the list
+    let excludeAppNameKey = props.props.filter((data: { key: string; }) => data.key !== 'appName'); //Dirty fix that excludes the appName URL param/value from being rendered in the list - this should probably be introduced deeper in the URL param parsing logic but this is the easiest place to put it for now
     return excludeAppNameKey.map( ( props: any ) => ( <TextField key={props.key} label={props.key} readOnly value={props.value} /> ) );
   }
 };

--- a/src/app/components/ListItemsComponent.tsx
+++ b/src/app/components/ListItemsComponent.tsx
@@ -9,16 +9,18 @@ const NoParamsMessage = () => {
       <>
         <Text>This app generates components based on URL search params specified in the URL</Text>
         <Text>To see it in action, add some params to the URL in the "example.com?key=value" format</Text>
+        <br/>
+        <Text variant={'small'}>Psst - you can now set the app heading to a custom title using the "appName" parameter</Text>
       </>
     </>
   );
 }
 
 const ListItemsComponent = ( props: any ) => {
-  let excludeAppNameKey = props.props.filter((data: { key: string; }) => data.key !== 'appName'); //Dirty fix that excludes the appName URL param/value from being rendered in the list
   if ( props.props === undefined ) {
     return <NoParamsMessage />
   } else {
+    let excludeAppNameKey = props.props.filter((data: { key: string; }) => data.key !== 'appName'); //Dirty fix that excludes the appName URL param/value from being rendered in the list
     return excludeAppNameKey.map( ( props: any ) => ( <TextField key={props.key} label={props.key} readOnly value={props.value} /> ) );
   }
 };

--- a/src/app/components/ListItemsComponent.tsx
+++ b/src/app/components/ListItemsComponent.tsx
@@ -15,11 +15,12 @@ const NoParamsMessage = () => {
 }
 
 const ListItemsComponent = ( props: any ) => {
+  let excludeAppNameKey = props.props.filter((data: { key: string; }) => data.key !== 'appName'); //Dirty fix that excludes the appName URL param/value from being rendered in the list
   if ( props.props === undefined ) {
     return <NoParamsMessage />
   } else {
-    return props.props.map( ( props: any ) => ( <TextField key={props.key} label={props.key} readOnly value={props.value} /> ) );
+    return excludeAppNameKey.map( ( props: any ) => ( <TextField key={props.key} label={props.key} readOnly value={props.value} /> ) );
   }
 };
 
-export default ListItemsComponent
+export default ListItemsComponent;

--- a/src/app/utils.ts
+++ b/src/app/utils.ts
@@ -68,7 +68,16 @@ export const utils = {
         }
       }
       let out = Object.entries(obj).map(([k, v]) => ({ key: k, value: v }));
+    
       return out;
+    }
+  },
+  isAppNameInUrl() {
+    let params = new URLSearchParams(document.location.search);
+    if (params.has("appName")) {
+      return params.get("appName");
+    } else {
+      return 'Michael\'s URL Param Tester'
     }
   },
   checkLightThemeSetting() {


### PR DESCRIPTION
Allows users to set App Header with the "appName" Param and includes necessary logic to make sure that the "appName" key/value does not get rendered to the list as well